### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -1,4 +1,6 @@
 name: contoso-traders-provisioning-deployment
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1263/DevOps-DevSecOps-Hackathon-lab-files/security/code-scanning/2](https://github.com/github-cloudlabsuser-1263/DevOps-DevSecOps-Hackathon-lab-files/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow involves actions like checking out code, logging into Azure, and deploying resources, we will start with minimal permissions (`contents: read`) and add additional permissions only if necessary. This ensures that the `GITHUB_TOKEN` has the least privileges required to complete the workflow.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
